### PR TITLE
chore(gitignore): populate gitignore for `Next.js` project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,30 @@
-#empty
+# Git ignore rules for LegalPro v1.0.1
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Test coverage reports
+coverage/
+*.lcov
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.env


### PR DESCRIPTION
This commit adds files that should not be commited to `.gitignore`.

This ensures we do not accidentally commit the bulky `node_modules` directory to version control.

